### PR TITLE
Remove the need to Box rcl_node_t

### DIFF
--- a/rclrs/src/client.rs
+++ b/rclrs/src/client.rs
@@ -43,7 +43,7 @@ impl Drop for ClientHandle {
         // SAFETY: The entity lifecycle mutex is locked to protect against the risk of
         // global variables in the rmw implementation being unsafely modified during cleanup.
         unsafe {
-            rcl_client_fini(rcl_client, &mut **rcl_node);
+            rcl_client_fini(rcl_client, &mut *rcl_node);
         }
     }
 }
@@ -115,7 +115,7 @@ where
             unsafe {
                 rcl_client_init(
                     &mut rcl_client,
-                    &**rcl_node,
+                    &*rcl_node,
                     type_support,
                     topic_c_string.as_ptr(),
                     &client_options,
@@ -263,7 +263,7 @@ where
     pub fn service_is_ready(&self) -> Result<bool, RclrsError> {
         let mut is_ready = false;
         let client = &mut *self.handle.rcl_client.lock().unwrap();
-        let node = &mut **self.handle.node_handle.rcl_node.lock().unwrap();
+        let node = &mut *self.handle.node_handle.rcl_node.lock().unwrap();
 
         unsafe {
             // SAFETY both node and client are guaranteed to be valid here

--- a/rclrs/src/node/builder.rs
+++ b/rclrs/src/node/builder.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::CString,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, atomic::AtomicBool},
 };
 
 use crate::{
@@ -276,8 +276,13 @@ impl NodeBuilder {
         let rcl_node_options = self.create_rcl_node_options()?;
         let rcl_context = &mut *self.context.rcl_context.lock().unwrap();
 
-        // SAFETY: Getting a zero-initialized value is always safe.
-        let mut rcl_node = Box::new(unsafe { rcl_get_zero_initialized_node() });
+        let handle = Arc::new(NodeHandle {
+            // SAFETY: Getting a zero-initialized value is always safe.
+            rcl_node: Mutex::new(unsafe { rcl_get_zero_initialized_node() }),
+            context_handle: Arc::clone(&self.context),
+            initialized: AtomicBool::new(false),
+        });
+
         unsafe {
             // SAFETY:
             // * The rcl_node is zero-initialized as mandated by this function.
@@ -287,7 +292,7 @@ impl NodeBuilder {
             //   global variables in the rmw implementation being unsafely modified during cleanup.
             let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
             rcl_node_init(
-                &mut *rcl_node,
+                &mut *handle.rcl_node.lock().unwrap(),
                 node_name.as_ptr(),
                 node_namespace.as_ptr(),
                 rcl_context,
@@ -296,10 +301,8 @@ impl NodeBuilder {
             .ok()?;
         };
 
-        let handle = Arc::new(NodeHandle {
-            rcl_node: Mutex::new(rcl_node),
-            context_handle: Arc::clone(&self.context),
-        });
+        handle.initialized.store(true, std::sync::atomic::Ordering::Release);
+
         let parameter = {
             let rcl_node = handle.rcl_node.lock().unwrap();
             ParameterInterface::new(

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -139,7 +139,7 @@ impl Node {
         unsafe {
             let rcl_node = self.handle.rcl_node.lock().unwrap();
             rcl_get_topic_names_and_types(
-                &**rcl_node,
+                &*rcl_node,
                 &mut rcutils_get_default_allocator(),
                 false,
                 &mut rcl_names_and_types,
@@ -169,7 +169,7 @@ impl Node {
         unsafe {
             let rcl_node = self.handle.rcl_node.lock().unwrap();
             rcl_get_node_names(
-                &**rcl_node,
+                &*rcl_node,
                 rcutils_get_default_allocator(),
                 &mut rcl_names,
                 &mut rcl_namespaces,
@@ -217,7 +217,7 @@ impl Node {
         unsafe {
             let rcl_node = self.handle.rcl_node.lock().unwrap();
             rcl_get_node_names_with_enclaves(
-                &**rcl_node,
+                &*rcl_node,
                 rcutils_get_default_allocator(),
                 &mut rcl_names,
                 &mut rcl_namespaces,
@@ -266,7 +266,7 @@ impl Node {
         // SAFETY: The topic_name string was correctly allocated previously
         unsafe {
             let rcl_node = self.handle.rcl_node.lock().unwrap();
-            rcl_count_publishers(&**rcl_node, topic_name.as_ptr(), &mut count).ok()?
+            rcl_count_publishers(&*rcl_node, topic_name.as_ptr(), &mut count).ok()?
         };
         Ok(count)
     }
@@ -282,7 +282,7 @@ impl Node {
         // SAFETY: The topic_name string was correctly allocated previously
         unsafe {
             let rcl_node = self.handle.rcl_node.lock().unwrap();
-            rcl_count_subscribers(&**rcl_node, topic_name.as_ptr(), &mut count).ok()?
+            rcl_count_subscribers(&*rcl_node, topic_name.as_ptr(), &mut count).ok()?
         };
         Ok(count)
     }
@@ -333,7 +333,7 @@ impl Node {
         unsafe {
             let rcl_node = self.handle.rcl_node.lock().unwrap();
             getter(
-                &**rcl_node,
+                &*rcl_node,
                 &mut rcutils_get_default_allocator(),
                 node_name.as_ptr(),
                 node_namespace.as_ptr(),
@@ -369,7 +369,7 @@ impl Node {
         unsafe {
             let rcl_node = self.handle.rcl_node.lock().unwrap();
             getter(
-                &**rcl_node,
+                &*rcl_node,
                 &mut rcutils_get_default_allocator(),
                 topic.as_ptr(),
                 false,

--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -10,7 +10,10 @@ pub use value::*;
 
 use crate::vendor::rcl_interfaces::msg::rmw::{ParameterType, ParameterValue as RmwParameterValue};
 
-use crate::{call_string_getter_with_rcl_node, rcl_bindings::*, Node, RclrsError};
+use crate::{
+    call_string_getter_with_rcl_node, rcl_bindings::*, Node, RclrsError,
+    ENTITY_LIFECYCLE_MUTEX,
+};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     fmt::Debug,
@@ -760,6 +763,7 @@ impl ParameterInterface {
         global_arguments: &rcl_arguments_t,
     ) -> Result<Self, RclrsError> {
         let override_map = unsafe {
+            let _lifecycle_lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
             let fqn = call_string_getter_with_rcl_node(rcl_node, rcl_node_get_fully_qualified_name);
             resolve_parameter_overrides(&fqn, node_arguments, global_arguments)?
         };

--- a/rclrs/src/publisher.rs
+++ b/rclrs/src/publisher.rs
@@ -38,7 +38,7 @@ impl Drop for PublisherHandle {
         // SAFETY: The entity lifecycle mutex is locked to protect against the risk of
         // global variables in the rmw implementation being unsafely modified during cleanup.
         unsafe {
-            rcl_publisher_fini(self.rcl_publisher.get_mut().unwrap(), &mut **rcl_node);
+            rcl_publisher_fini(self.rcl_publisher.get_mut().unwrap(), &mut *rcl_node);
         }
     }
 }
@@ -111,7 +111,7 @@ where
                 //   variables in the rmw implementation being unsafely modified during cleanup.
                 rcl_publisher_init(
                     &mut rcl_publisher,
-                    &**rcl_node,
+                    &*rcl_node,
                     type_support_ptr,
                     topic_c_string.as_ptr(),
                     &publisher_options,

--- a/rclrs/src/service.rs
+++ b/rclrs/src/service.rs
@@ -41,7 +41,7 @@ impl Drop for ServiceHandle {
         // SAFETY: The entity lifecycle mutex is locked to protect against the risk of
         // global variables in the rmw implementation being unsafely modified during cleanup.
         unsafe {
-            rcl_service_fini(rcl_service, &mut **rcl_node);
+            rcl_service_fini(rcl_service, &mut *rcl_node);
         }
     }
 }
@@ -116,7 +116,7 @@ where
                 //   variables in the rmw implementation being unsafely modified during initialization.
                 rcl_service_init(
                     &mut rcl_service,
-                    &**rcl_node,
+                    &*rcl_node,
                     type_support,
                     topic_c_string.as_ptr(),
                     &service_options as *const _,

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -49,7 +49,7 @@ impl Drop for SubscriptionHandle {
         // SAFETY: The entity lifecycle mutex is locked to protect against the risk of
         // global variables in the rmw implementation being unsafely modified during cleanup.
         unsafe {
-            rcl_subscription_fini(rcl_subscription, &mut **rcl_node);
+            rcl_subscription_fini(rcl_subscription, &mut *rcl_node);
         }
     }
 }
@@ -129,7 +129,7 @@ where
                 //   variables in the rmw implementation being unsafely modified during cleanup.
                 rcl_subscription_init(
                     &mut rcl_subscription,
-                    &**rcl_node,
+                    &*rcl_node,
                     type_support,
                     topic_c_string.as_ptr(),
                     &subscription_options,


### PR DESCRIPTION
I was able to recreate the crash that happens in humble, as discussed [here](https://github.com/ros2-rust/ros2_rust/pull/422#discussion_r1822560373). It does seem that in Humble rcl is doing some questionable things with the `rcl_node_t` address.

This PR offers an alternative solution that does not require us to Box the `rcl_node_t`. Instead we initialize the `rcl_node_t` while it is already positioned inside the `NodeHandle`. Since the `NodeHandle` has a fixed memory address throughout its lifetime, the `rcl_node_t` will also have a fixed address.

The only downside is we need to add another variable to `NodeHandle` to track whether the `rcl_node_t` was successfully initialized, otherwise it might attempt to call `rcl_node_fini` on an invalid `rcl_node_t` instance which lead to bad and confusing behavior in the tests. I think overall this is less disruptive than adding a layer of indirection to `rcl_node_t`.