### PR TITLE
Fix logging lifecycles and clean up tests

### DIFF
--- a/rclrs/src/logging/logging_configuration.rs
+++ b/rclrs/src/logging/logging_configuration.rs
@@ -1,0 +1,53 @@
+use std::sync::{Mutex, Weak, LazyLock, Arc};
+
+use crate::{
+    RclrsError, ENTITY_LIFECYCLE_MUTEX, ToResult,
+    rcl_bindings::{
+        rcl_context_t, rcl_arguments_t, rcutils_get_default_allocator,
+        rcl_logging_configure, rcl_logging_fini,
+    },
+};
+
+
+struct LoggingConfiguration {
+    lifecycle: Mutex<Weak<LoggingLifecycle>>,
+}
+
+pub(crate) struct LoggingLifecycle;
+
+impl LoggingLifecycle {
+    fn new(args: &rcl_arguments_t) -> Result<Self, RclrsError> {
+        // SAFETY:
+        // * Lock the mutex as we cannot guarantee that rcl_* functions are protecting their global variables
+        // * This is only called by Self::configure, which requires that a valid context was passed to it
+        // * No other preconditions for calling this function
+        unsafe {
+            let allocator = rcutils_get_default_allocator();
+            let _lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
+            rcl_logging_configure(args, &allocator).ok()?;
+        }
+        Ok(Self)
+    }
+
+    /// SAFETY: Ensure rcl_context_t is valid before passing it in.
+    pub(crate) unsafe fn configure(context: &rcl_context_t) -> Result<Arc<LoggingLifecycle>, RclrsError> {
+        static CONFIGURATION: LazyLock<LoggingConfiguration> = LazyLock::new(
+            || LoggingConfiguration { lifecycle: Mutex::new(Weak::new())}
+        );
+
+        let mut lifecycle = CONFIGURATION.lifecycle.lock().unwrap();
+        if let Some(arc_lifecycle) = lifecycle.upgrade() {
+            return Ok(arc_lifecycle);
+        }
+        let arc_lifecycle = Arc::new(LoggingLifecycle::new(&context.global_arguments)?);
+        *lifecycle = Arc::downgrade(&arc_lifecycle);
+        Ok(arc_lifecycle)
+    }
+}
+
+impl Drop for LoggingLifecycle {
+    fn drop(&mut self) {
+        let _lock = ENTITY_LIFECYCLE_MUTEX.lock().unwrap();
+        unsafe { rcl_logging_fini(); }
+    }
+}

--- a/rclrs/src/node.rs
+++ b/rclrs/src/node.rs
@@ -539,15 +539,15 @@ mod tests {
     #[test]
     fn test_logger_name() -> Result<(), RclrsError> {
         // Use helper to create 2 nodes for us
-        let graph = construct_test_graph("test_topics_graph")?;
+        let graph = construct_test_graph("test_logger_name")?;
 
         assert_eq!(
             graph.node1.logger_name(),
-            "test_topics_graph.graph_test_node_1"
+            "test_logger_name.graph_test_node_1"
         );
         assert_eq!(
             graph.node2.logger_name(),
-            "test_topics_graph.graph_test_node_2"
+            "test_logger_name.graph_test_node_2"
         );
 
         Ok(())

--- a/rclrs/src/node/graph.rs
+++ b/rclrs/src/node/graph.rs
@@ -487,12 +487,13 @@ mod tests {
                 .unwrap();
         let node_name = "test_publisher_names_and_types";
         let node = Node::new(&context, node_name).unwrap();
-        // Test that the graph has no publishers
+        // Test that the graph has no publishers besides /rosout
         let names_and_topics = node
             .get_publisher_names_and_types_by_node(node_name, "")
             .unwrap();
 
-        assert_eq!(names_and_topics.len(), 0);
+        assert_eq!(names_and_topics.len(), 1);
+        assert_eq!(names_and_topics.get("/rosout").unwrap().first().unwrap(), "rcl_interfaces/msg/Log");
 
         let num_publishers = node.count_publishers("/test").unwrap();
 
@@ -535,10 +536,11 @@ mod tests {
 
         assert_eq!(names_and_topics.len(), 0);
 
-        // Test that the graph has no topics
+        // Test that the graph has no topics besides /rosout
         let names_and_topics = node.get_topic_names_and_types().unwrap();
 
-        assert_eq!(names_and_topics.len(), 0);
+        assert_eq!(names_and_topics.len(), 1);
+        assert_eq!(names_and_topics.get("/rosout").unwrap().first().unwrap(), "rcl_interfaces/msg/Log");
     }
 
     #[test]

--- a/rclrs/src/parameter.rs
+++ b/rclrs/src/parameter.rs
@@ -882,7 +882,7 @@ mod tests {
             String::from("declared_int:=10"),
         ])
         .unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = create_node(&ctx, &format!("param_test_node_{}", line!())).unwrap();
 
         // Declaring a parameter with a different type than what was overridden should return an
         // error
@@ -940,7 +940,7 @@ mod tests {
             String::from("non_declared_string:='param'"),
         ])
         .unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = create_node(&ctx, &format!("param_test_node_{}", line!())).unwrap();
 
         let overridden_int = node
             .declare_parameter("declared_int")
@@ -1090,7 +1090,7 @@ mod tests {
             String::from("declared_int:=10"),
         ])
         .unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = create_node(&ctx, &format!("param_test_node_{}", line!())).unwrap();
         // If a parameter was set as an override and as an undeclared parameter, the undeclared
         // value should get priority
         node.use_undeclared_parameters()
@@ -1112,7 +1112,7 @@ mod tests {
             String::from("declared_int:=10"),
         ])
         .unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = create_node(&ctx, &format!("param_test_node_{}", line!())).unwrap();
         {
             // Setting a parameter with an override
             let param = node
@@ -1158,7 +1158,7 @@ mod tests {
     #[test]
     fn test_parameter_ranges() {
         let ctx = Context::new([]).unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = create_node(&ctx, &format!("param_test_node_{}", line!())).unwrap();
         // Setting invalid ranges should fail
         let range = ParameterRange {
             lower: Some(10),
@@ -1286,7 +1286,7 @@ mod tests {
     #[test]
     fn test_readonly_parameters() {
         let ctx = Context::new([]).unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = create_node(&ctx, &format!("param_test_node_{}", line!())).unwrap();
         let param = node
             .declare_parameter("int_param")
             .default(100)
@@ -1313,7 +1313,7 @@ mod tests {
     #[test]
     fn test_preexisting_value_error() {
         let ctx = Context::new([]).unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = create_node(&ctx, &format!("param_test_node_{}", line!())).unwrap();
         node.use_undeclared_parameters()
             .set("int_param", 100)
             .unwrap();
@@ -1366,7 +1366,7 @@ mod tests {
     #[test]
     fn test_optional_parameter_apis() {
         let ctx = Context::new([]).unwrap();
-        let node = create_node(&ctx, "param_test_node").unwrap();
+        let node = create_node(&ctx, &format!("param_test_node_{}", line!())).unwrap();
         node.declare_parameter::<i64>("int_param")
             .optional()
             .unwrap();

--- a/rclrs/src/subscription.rs
+++ b/rclrs/src/subscription.rs
@@ -381,7 +381,7 @@ mod tests {
 
         // Test get_subscriptions_info_by_topic()
         let expected_subscriptions_info = vec![TopicEndpointInfo {
-            node_name: String::from("graph_test_node_2"),
+            node_name: format!("graph_test_node_2"),
             node_namespace: String::from(namespace),
             topic_type: String::from("test_msgs/msg/Empty"),
         }];

--- a/rclrs/src/time_source.rs
+++ b/rclrs/src/time_source.rs
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn time_source_default_clock() {
-        let node = create_node(&Context::new([]).unwrap(), "test_node").unwrap();
+        let node = create_node(&Context::new([]).unwrap(), &format!("time_source_test_node_{}", line!())).unwrap();
         // Default clock should be above 0 (use_sim_time is default false)
         assert!(node.get_clock().now().nsec > 0);
     }
@@ -162,7 +162,7 @@ mod tests {
             String::from("use_sim_time:=true"),
         ])
         .unwrap();
-        let node = create_node(&ctx, "test_node").unwrap();
+        let node = create_node(&ctx, &format!("time_source_test_node_{}", line!())).unwrap();
         // Default sim time value should be 0 (no message received)
         assert_eq!(node.get_clock().now().nsec, 0);
     }


### PR DESCRIPTION
This PR addresses two points of feedback:
* Make sure that logging is only configured once and only fini-ed when all contexts are gone [[1]](https://github.com/ros2-rust/ros2_rust/pull/422#discussion_r1822869992)
* Use ENTITY_LIFECYCLE_MUTEX to protect against race conditions [[2]](https://github.com/ros2-rust/ros2_rust/pull/422#discussion_r1822820246)

While making this PR I uncovered a fault in one of the tests which didn't show up because of the flawed teardown of logging: The empty graph tests should now show that a `/rosout` node exists and that it has one topic.

I also took the liberty of cleaning up the tests to make sure that each test creates a node with a unique name, because otherwise we get spammed with warnings which might mislead someone into thinking that something is wrong with rclrs or its tests.